### PR TITLE
rename next -> _next. next() is a builtin

### DIFF
--- a/OTXv2.py
+++ b/OTXv2.py
@@ -92,12 +92,12 @@ class OTXv2(object):
         :return: the consolidated set of pulses for the user
         """
         pulses = []
-        next = self.create_url(SUBSCRIBED, limit=limit)
-        while next:
-            json_data = self.get(next)
+        _next = self.create_url(SUBSCRIBED, limit=limit)
+        while _next:
+            json_data = self.get(_next)
             for r in json_data["results"]:
                 pulses.append(r)
-            next = json_data["next"]
+            _next = json_data["next"]
         return pulses
 
     def getall_iter(self, limit=20):
@@ -106,12 +106,12 @@ class OTXv2(object):
         :return:
         """
         pulses = []
-        next = self.create_url(SUBSCRIBED, limit=limit)
-        while next:
-            json_data = self.get(next)
+        _next = self.create_url(SUBSCRIBED, limit=limit)
+        while _next:
+            json_data = self.get(_next)
             for r in json_data["results"]:
                 yield r
-            next = json_data["next"]
+            _next = json_data["next"]
 
     def getsince(self, mytimestamp, limit=20):
         """
@@ -121,22 +121,22 @@ class OTXv2(object):
         :return: the consolidated set of pulses for the user
         """
         pulses = []
-        next = self.create_url(SUBSCRIBED, limit=limit, modified_since=mytimestamp)
-        while next:
-            json_data = self.get(next)
+        _next = self.create_url(SUBSCRIBED, limit=limit, modified_since=mytimestamp)
+        while _next:
+            json_data = self.get(_next)
             for r in json_data["results"]:
                 pulses.append(r)
-            next = json_data["next"]
+            _next = json_data["next"]
         return pulses
 
     def getsince_iter(self, mytimestamp, limit=20):
         pulses = []
-        next = self.create_url(SUBSCRIBED, limit=limit, modified_since=mytimestamp)
-        while next:
-            json_data = self.get(next)
+        _next = self.create_url(SUBSCRIBED, limit=limit, modified_since=mytimestamp)
+        while _next:
+            json_data = self.get(_next)
             for r in json_data["results"]:
                 yield r
-            next = json_data["next"]
+            _next = json_data["next"]
 
     def get_all_indicators(self, indicator_types=IndicatorTypes.all_types):
         """
@@ -159,10 +159,10 @@ class OTXv2(object):
         :return: the consolidated set of pulses for the user
         """
         events = []
-        next = self.create_url(EVENTS, limit=limit, since=mytimestamp)
-        while next:
-            json_data = self.get(next)
+        _next = self.create_url(EVENTS, limit=limit, since=mytimestamp)
+        while _next:
+            json_data = self.get(_next)
             for r in json_data["results"]:
                 events.append(r)
-            next = json_data["next"]
+            _next = json_data["next"]
         return events


### PR DESCRIPTION
small change incase anyone tries to use next() with one of the generators (used by ```for x in y```).

https://jeffknupp.com/blog/2013/04/07/improve-your-python-yield-and-generators-explained/