### PR TITLE
Api docs release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,94 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask instance folder
+instance/
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# IntelliJ cruft
+.idea/*
+
 build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_script:
  - chmod +x tests/test_client.py
 
 # command to run tests
-script: tests/test_client.py
+script: python tests/test_client.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ python:
 install:
   - python setup.py install
 
+before_script:
+ - chmod +x tests/test_client.py
+
 # command to run tests
 script: tests/test_client.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - 2.7
+  - 3.4
+# command to install dependencies
+install: "pip install -r requirements.txt"
+# command to run tests
+script: tests/test_client.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ python:
   - 2.7
   - 3.4
 # command to install dependencies
-install: "pip install -r requirements.txt"
+#install: "pip install -r requirements.txt"
+
+install:
+  - python setup.py install
+
 # command to run tests
 script: tests/test_client.py

--- a/IndicatorTypes.py
+++ b/IndicatorTypes.py
@@ -23,11 +23,11 @@ class IndicatorTypes(object):
 IPv4 = IndicatorTypes(name="IPv4",
                       description="An IPv4 address indicating the online location of a server or other computer.",
                       api_support=True,
-                      sections=["general", "pulses", "reputation", "geo", "malware", "address_list", "url_list"])
+                      sections=["general", "reputation", "geo", "malware", "address_list", "url_list"])
 IPv6 = IndicatorTypes(name="IPv6",
                       description="An IPv6 address indicating the online location of a server or other computer.",
                       api_support=True,
-                      sections=["general", "pulses", "reputation", "geo", "malware", "address_list", "url_list"])
+                      sections=["general", "reputation", "geo", "malware", "address_list", "url_list"])
 DOMAIN = IndicatorTypes(name="domain",
                         description="A domain name for a website or server. Domains encompass a series of hostnames.",
                         api_support=True,

--- a/IndicatorTypes.py
+++ b/IndicatorTypes.py
@@ -7,11 +7,12 @@ class IndicatorTypes(object):
     :var api_support if true, indicator api is supported for this type.
     :var sections indicator List of valid sections for this type (api is split into sections).
     """
-    def __init__(self, name, description, api_support=False, sections=None):
+    def __init__(self, name, description, api_support=False, sections=None, slug=None):
         self.name = name
         self.description = description
         self.api_support = api_support
         self.sections = sections
+        self.slug = slug
 
     def __str__(self):
         return "<IndicatorTypes: {}>".format(self.name)
@@ -23,39 +24,47 @@ class IndicatorTypes(object):
 IPv4 = IndicatorTypes(name="IPv4",
                       description="An IPv4 address indicating the online location of a server or other computer.",
                       api_support=True,
-                      sections=["general", "reputation", "geo", "malware", "address_list", "url_list"])
+                      sections=["general", "reputation", "geo", "malware", "address_list", "url_list"],
+                      slug="IPv4")
 IPv6 = IndicatorTypes(name="IPv6",
                       description="An IPv6 address indicating the online location of a server or other computer.",
                       api_support=True,
-                      sections=["general", "reputation", "geo", "malware", "address_list", "url_list"])
+                      sections=["general", "reputation", "geo", "malware", "address_list", "url_list"],
+                      slug="IPv6")
 DOMAIN = IndicatorTypes(name="domain",
                         description="A domain name for a website or server. Domains encompass a series of hostnames.",
                         api_support=True,
-                        sections=["general", "geo", "malware", "url_list", "address_list"])
+                        sections=["general", "geo", "malware", "url_list", "address_list"],
+                        slug="domain")
 HOSTNAME = IndicatorTypes(name="hostname",
                           description="The hostname for a server located within a domain.",
                           api_support=True,
-                          sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"])
+                          sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"],
+                          slug="hostname")
 EMAIL = IndicatorTypes(name="email", description="An email associated with suspicious activity.")
 URL = IndicatorTypes(name="URL",
                      description=" Uniform Resource Location (URL) summarizing the online location of a file or resource.",
                      api_support=True,
-                     sections=["general", "url_list"])
+                     sections=["general", "url_list"],
+                     slug="url")
 URI = IndicatorTypes(name="URI",
                      description="Uniform Resource Indicator (URI) describing"
                                  " the explicit path to a file hosted online.")
 FILE_HASH_MD5 = IndicatorTypes(name="FileHash-MD5",
                                description="A MD5-format hash that summarizes the architecture and content of a file.",
                                api_support=True,
-                               sections=["general", "analysis", "malware", "passive_dns", "url_list"])
+                               sections=["general", "analysis", "malware", "passive_dns", "url_list"],
+                               slug="file")
 FILE_HASH_SHA1 = IndicatorTypes(name="FileHash-SHA1",
                                 description="A SHA-format hash that summarizes the architecture and content of a file.",
                                 api_support=True,
-                                sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"])
+                                sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"],
+                                slug="file")
 FILE_HASH_SHA256 = IndicatorTypes(name="FileHash-SHA256",
                                   description="A SHA-256-format hash that summarizes the architecture and content of a file.",
                                   api_support=True,
-                                  sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"])
+                                  sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"],
+                                  slug="file")
 FILE_HASH_PEHASH = IndicatorTypes(name="FileHash-PEHASH",
                                   description="A PEPHASH-format hash that summarizes the"
                                               " architecture and content of a file.")
@@ -75,7 +84,8 @@ CVE = IndicatorTypes(name="CVE",
                                  " describing a software vulnerability that can be"
                                  " exploited to engage in malicious activity.",
                      api_support=True,
-                     sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"])
+                     sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"],
+                     slug="cve")
 
 # all_types list of supported IOC types for pulse indicators
 all_types = [IPv4,

--- a/IndicatorTypes.py
+++ b/IndicatorTypes.py
@@ -1,32 +1,61 @@
 class IndicatorTypes(object):
-    def __init__(self, name, description):
+    """
+    IndicatorTypes object define indicators used in OTX.
+
+    :var name string recognized by the OTX platform.
+    :var description string verbose description of what the type denotes.
+    :var api_support if true, indicator api is supported for this type.
+    :var sections indicator List of valid sections for this type (api is split into sections).
+    """
+    def __init__(self, name, description, api_support=False, sections=None):
         self.name = name
         self.description = description
+        self.api_support = api_support
+        self.sections = sections
+
+    def __str__(self):
+        return "<IndicatorTypes: {}>".format(self.name)
+
+    def __unicode__(self):
+        return u"<IndicatorTypes: {}>".format(self.name)
 
 
 IPv4 = IndicatorTypes(name="IPv4",
-                      description="An IPv4 address indicating the online location of a server or other computer.")
+                      description="An IPv4 address indicating the online location of a server or other computer.",
+                      api_support=True,
+                      sections=["general", "pulses", "reputation", "geo", "malware", "address_list", "url_list"])
 IPv6 = IndicatorTypes(name="IPv6",
-                      description="An IPv6 address indicating the online location of a server or other computer.")
+                      description="An IPv6 address indicating the online location of a server or other computer.",
+                      api_support=True,
+                      sections=["general", "pulses", "reputation", "geo", "malware", "address_list", "url_list"])
 DOMAIN = IndicatorTypes(name="domain",
-                        description="A domain name for a website or server. Domains encompass a series of hostnames.")
-HOSTNAME = IndicatorTypes(name="hostname", description="The hostname for a server located within a domain.")
+                        description="A domain name for a website or server. Domains encompass a series of hostnames.",
+                        api_support=True,
+                        sections=["general", "geo", "malware", "url_list", "address_list"])
+HOSTNAME = IndicatorTypes(name="hostname",
+                          description="The hostname for a server located within a domain.",
+                          api_support=True,
+                          sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"])
 EMAIL = IndicatorTypes(name="email", description="An email associated with suspicious activity.")
 URL = IndicatorTypes(name="URL",
-                     description=" Uniform Resource Location (URL) summarizing"
-                                 " the online location of a file or resource.")
+                     description=" Uniform Resource Location (URL) summarizing the online location of a file or resource.",
+                     api_support=True,
+                     sections=["general", "url_list"])
 URI = IndicatorTypes(name="URI",
                      description="Uniform Resource Indicator (URI) describing"
                                  " the explicit path to a file hosted online.")
 FILE_HASH_MD5 = IndicatorTypes(name="FileHash-MD5",
-                               description="A MD5-format hash that summarizes"
-                                           " the architecture and content of a file.")
+                               description="A MD5-format hash that summarizes the architecture and content of a file.",
+                               api_support=True,
+                               sections=["general", "analysis", "malware", "passive_dns", "url_list"])
 FILE_HASH_SHA1 = IndicatorTypes(name="FileHash-SHA1",
-                                description="A SHA-format hash that summarizes"
-                                            " the architecture and content of a file.")
+                                description="A SHA-format hash that summarizes the architecture and content of a file.",
+                                api_support=True,
+                                sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"])
 FILE_HASH_SHA256 = IndicatorTypes(name="FileHash-SHA256",
-                                  description="A SHA-256-format hash that summarizes"
-                                              " the architecture and content of a file.")
+                                  description="A SHA-256-format hash that summarizes the architecture and content of a file.",
+                                  api_support=True,
+                                  sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"])
 FILE_HASH_PEHASH = IndicatorTypes(name="FileHash-PEHASH",
                                   description="A PEPHASH-format hash that summarizes the"
                                               " architecture and content of a file.")
@@ -44,7 +73,11 @@ MUTEX = IndicatorTypes(name="Mutex",
 CVE = IndicatorTypes(name="CVE",
                      description="Common Vulnerability and Exposure (CVE) entry"
                                  " describing a software vulnerability that can be"
-                                 " exploited to engage in malicious activity.")
+                                 " exploited to engage in malicious activity.",
+                     api_support=True,
+                     sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"])
+
+# all_types list of supported IOC types for pulse indicators
 all_types = [IPv4,
              IPv6,
              DOMAIN,
@@ -61,6 +94,18 @@ all_types = [IPv4,
              FILE_PATH,
              MUTEX,
              CVE]
+
+# supported_api_types are a subset of all_types for which AlienVault OTX API can offer additional data, such as
+# static/dynamic analysis for files, passive dns for hostnames & domains, IP Reputation for IPs, CVE data, etc.
+supported_api_types = [IPv4,
+                       IPv6,
+                       DOMAIN,
+                       HOSTNAME,
+                       URL,
+                       FILE_HASH_MD5,
+                       FILE_HASH_SHA1,
+                       FILE_HASH_SHA256,
+                       CVE]
 
 
 def to_name_list(indicator_type_list):

--- a/IndicatorTypes.py
+++ b/IndicatorTypes.py
@@ -6,6 +6,8 @@ class IndicatorTypes(object):
     :var description string verbose description of what the type denotes.
     :var api_support if true, indicator api is supported for this type.
     :var sections indicator List of valid sections for this type (api is split into sections).
+    :var slug for building indicator details URLs, similar to name but not always unique (i.e. 'file' for all
+              hash types)
     """
     def __init__(self, name, description, api_support=False, sections=None, slug=None):
         self.name = name
@@ -15,35 +17,36 @@ class IndicatorTypes(object):
         self.slug = slug
 
     def __str__(self):
-        return "<IndicatorTypes: {}>".format(self.name)
+        return self.name
 
     def __unicode__(self):
-        return u"<IndicatorTypes: {}>".format(self.name)
+        return unicode(self.name)
 
 
 IPv4 = IndicatorTypes(name="IPv4",
                       description="An IPv4 address indicating the online location of a server or other computer.",
                       api_support=True,
-                      sections=["general", "reputation", "geo", "malware", "address_list", "url_list"],
+                      sections=["general", "reputation", "geo", "malware", "url_list", "passive_dns"],
                       slug="IPv4")
 IPv6 = IndicatorTypes(name="IPv6",
                       description="An IPv6 address indicating the online location of a server or other computer.",
                       api_support=True,
-                      sections=["general", "reputation", "geo", "malware", "address_list", "url_list"],
+                      sections=["general", "reputation", "geo", "malware", "url_list", "passive_dns"],
                       slug="IPv6")
 DOMAIN = IndicatorTypes(name="domain",
                         description="A domain name for a website or server. Domains encompass a series of hostnames.",
                         api_support=True,
-                        sections=["general", "geo", "malware", "url_list", "address_list"],
+                        sections=["general", "geo", "malware", "url_list", "passive_dns"],
                         slug="domain")
 HOSTNAME = IndicatorTypes(name="hostname",
                           description="The hostname for a server located within a domain.",
                           api_support=True,
-                          sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"],
+                          sections=["general", "geo", "malware", "url_list", "passive_dns"],
                           slug="hostname")
 EMAIL = IndicatorTypes(name="email", description="An email associated with suspicious activity.")
 URL = IndicatorTypes(name="URL",
-                     description=" Uniform Resource Location (URL) summarizing the online location of a file or resource.",
+                     description=" Uniform Resource Location (URL) summarizing the online location of a file or "
+                                 "resource.",
                      api_support=True,
                      sections=["general", "url_list"],
                      slug="url")
@@ -53,17 +56,18 @@ URI = IndicatorTypes(name="URI",
 FILE_HASH_MD5 = IndicatorTypes(name="FileHash-MD5",
                                description="A MD5-format hash that summarizes the architecture and content of a file.",
                                api_support=True,
-                               sections=["general", "analysis", "malware", "passive_dns", "url_list"],
+                               sections=["general", "analysis"],
                                slug="file")
 FILE_HASH_SHA1 = IndicatorTypes(name="FileHash-SHA1",
                                 description="A SHA-format hash that summarizes the architecture and content of a file.",
                                 api_support=True,
-                                sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"],
+                                sections=["general", "analysis"],
                                 slug="file")
 FILE_HASH_SHA256 = IndicatorTypes(name="FileHash-SHA256",
-                                  description="A SHA-256-format hash that summarizes the architecture and content of a file.",
+                                  description="A SHA-256-format hash that summarizes the architecture and content of a "
+                                              "file.",
                                   api_support=True,
-                                  sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"],
+                                  sections=["general", "analysis"],
                                   slug="file")
 FILE_HASH_PEHASH = IndicatorTypes(name="FileHash-PEHASH",
                                   description="A PEPHASH-format hash that summarizes the"
@@ -84,7 +88,7 @@ CVE = IndicatorTypes(name="CVE",
                                  " describing a software vulnerability that can be"
                                  " exploited to engage in malicious activity.",
                      api_support=True,
-                     sections=["general", "geo", "reputation", "malware", "passive_dns", "url_list"],
+                     sections=["general"],
                      slug="cve")
 
 # all_types list of supported IOC types for pulse indicators

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -114,7 +114,6 @@ class OTXv2(object):
                     encoded_error = e.read()
                     decoded_error = encoded_error.decode('utf-8')
                     json.loads(decoded_error)
-                    print("raising badrequest with {}".format(decoded_error))
                     raise BadRequest(decoded_error)
         return {}
 
@@ -209,7 +208,6 @@ class OTXv2(object):
         :param section: Section from IndicatorTypes.section.  Default is general info
         :return: formatted URL string
         """
-        print ("create_indicator_detail_url indicator_type: {}, indicator: {}, section: {}".format(indicator_type, indicator, section))
         indicator_url = self.create_url(INDICATOR_DETAILS)
         indicator_url = indicator_url + "{indicator_type}/{indicator}/{section}".format(indicator_type=indicator_type.slug,
                                                                                         indicator=indicator,

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -51,7 +51,7 @@ class OTXv2(object):
         self.key = api_key
         self.server = server
         self.proxy = proxy
-        self.sdk = 'OTX Python {}/1.0'.format(project)
+        self.sdk = 'OTX Python {}/1.1'.format(project)
 
     def get(self, url):
         """
@@ -137,6 +137,16 @@ class OTXv2(object):
             :param indicators(list of objects) IOCs to include in pulse
         :return: request body response
         :raises BadRequest (400) On failure, BadRequest will be raised containing the invalid fields.
+
+        Examples:
+        Python kwargs can be used in two ways.  You can call create_pulse passing a dict, or named arguments.
+        With a dict:
+            otx = OTXv2("mysecretkey")  # replace with your api key
+            body = {'name': pulse_name, 'public': False, 'indicators': indicator_list, 'TLP': 'green', ...}
+            otx.create_pulse(**body)  # the dict will be expanded into the args.
+        Or with named args:
+            otx = OTXv2("mysecretkey")  # replace with your api key
+            otx.create_pulse(name=pulse_name, public=False, indicators=indicator_list, TLP='green')
         """
         body = {
             'name': kwargs.get('name', ''),
@@ -357,9 +367,9 @@ class OTXv2(object):
 
     def get_pulse_indicators(self, pulse_id):
         """
-        For a given pulse_id, get indicators of compromise
-        :param pulse_id: timestamp to filter returned activity
-        :return: Pulse as dict
+        For a given pulse_id, get list of indicators (IOCs)
+        :param pulse_id: Object ID specify which pulse to get indicators from
+        :return: Indicator list
         """
         pulse_url = self.create_url(PULSE_DETAILS + str(pulse_id) + "/indicators")
         pulse_indicators_url = pulse_url
@@ -368,7 +378,7 @@ class OTXv2(object):
 
     def get_indicator_details_by_section(self, indicator_type, indicator, section='general'):
         """
-        Obtain a specific section for an indicator.
+        The Indicator details endpoints are split into sections.  Obtain a specific section for an indicator.
         :param indicator_type: IndicatorType instance
         :param indicator: String indicator (i.e. "69.73.130.198", "mail.vspcord.com")
         :param section: Section from IndicatorTypes.section.  Default is general info

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -153,7 +153,7 @@ class OTXv2(object):
             raise ValueError('Name required.  Please resubmit your pulse with a name (string, 5-64 chars).')
         return self.post(self.create_url(PULSE_CREATE), body=body)
 
-    def validate_indicator(self, indicator, indicator_type, description=""):
+    def validate_indicator(self, indicator_type, indicator, description=""):
         """
         The goal of validate_indicator is to aid you in pulse creation.  Use this method on each indicator before
         calling create_pulse to ensure success in the create call.  If you supply invalid indicators in a create call,
@@ -209,6 +209,7 @@ class OTXv2(object):
         :param section: Section from IndicatorTypes.section.  Default is general info
         :return: formatted URL string
         """
+        print ("create_indicator_detail_url indicator_type: {}, indicator: {}, section: {}".format(indicator_type, indicator, section))
         indicator_url = self.create_url(INDICATOR_DETAILS)
         indicator_url = indicator_url + "{indicator_type}/{indicator}/{section}".format(indicator_type=indicator_type.name,
                                                                                         indicator=indicator,
@@ -384,13 +385,15 @@ class OTXv2(object):
         indicator_details = self.get(indicator_url)
         return indicator_details
 
-    def get_full_indicator_details(self, indicator_type, indicator):
+    def get_indicator_details_full(self, indicator_type, indicator):
         """
         Obtain all sections for an indicator.
         :param indicator_type: IndicatorType instance
         :param indicator: String indicator (i.e. "69.73.130.198", "mail.vspcord.com")
         :return: dict with sections as keys and results for each call as values.
         """
-        indicator_url = self.create_indicator_detail_url(indicator_type, indicator)
-        indicator_details = self.get(indicator_url)
-        return indicator_details
+        indicator_dict = {}
+        for section in indicator_type.sections:
+            indicator_url = self.create_indicator_detail_url(indicator_type, indicator, section)
+            indicator_dict[section] = self.get(indicator_url)
+        return indicator_dict

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -110,7 +110,6 @@ class OTXv2(object):
         :param limit:
         :return:
         """
-        pulses = []
         next_page = self.create_url(SUBSCRIBED, limit=limit)
         while next_page:
             json_data = self.get(next_page)
@@ -135,7 +134,6 @@ class OTXv2(object):
         return pulses
 
     def getsince_iter(self, mytimestamp, limit=20):
-        pulses = []
         next_page = self.create_url(SUBSCRIBED, limit=limit, modified_since=mytimestamp)
         while next_page:
             json_data = self.get(next_page)

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -9,6 +9,8 @@ API_V1_ROOT = "{}/api/v1/"
 PULSES_ROOT = "{}/pulses".format(API_V1_ROOT)
 SUBSCRIBED = "{}/subscribed".format(PULSES_ROOT)
 EVENTS = "{}/events".format(PULSES_ROOT)
+SEARCH_PULSES = "{}/search/".format(API_V1_ROOT)
+SEARCH_USERS = SEARCH_PULSES + "users/"
 
 try:
     # For Python2
@@ -95,12 +97,12 @@ class OTXv2(object):
         :return: the consolidated set of pulses for the user
         """
         pulses = []
-        next = self.create_url(SUBSCRIBED, limit=limit)
-        while next:
-            json_data = self.get(next)
+        next_page = self.create_url(SUBSCRIBED, limit=limit)
+        while next_page:
+            json_data = self.get(next_page)
             for r in json_data["results"]:
                 pulses.append(r)
-            next = json_data["next"]
+            next_page = json_data["next"]
         return pulses
 
     def getall_iter(self, limit=20):
@@ -109,12 +111,12 @@ class OTXv2(object):
         :return:
         """
         pulses = []
-        next = self.create_url(SUBSCRIBED, limit=limit)
-        while next:
-            json_data = self.get(next)
+        next_page = self.create_url(SUBSCRIBED, limit=limit)
+        while next_page:
+            json_data = self.get(next_page)
             for r in json_data["results"]:
                 yield r
-            next = json_data["next"]
+            next_page = json_data["next"]
 
     def getsince(self, mytimestamp, limit=20):
         """
@@ -124,22 +126,38 @@ class OTXv2(object):
         :return: the consolidated set of pulses for the user
         """
         pulses = []
-        next = self.create_url(SUBSCRIBED, limit=limit, modified_since=mytimestamp)
-        while next:
-            json_data = self.get(next)
+        next_page = self.create_url(SUBSCRIBED, limit=limit, modified_since=mytimestamp)
+        while next_page:
+            json_data = self.get(next_page)
             for r in json_data["results"]:
                 pulses.append(r)
-            next = json_data["next"]
+            next_page = json_data["next"]
         return pulses
 
     def getsince_iter(self, mytimestamp, limit=20):
         pulses = []
-        next = self.create_url(SUBSCRIBED, limit=limit, modified_since=mytimestamp)
-        while next:
-            json_data = self.get(next)
+        next_page = self.create_url(SUBSCRIBED, limit=limit, modified_since=mytimestamp)
+        while next_page:
+            json_data = self.get(next_page)
             for r in json_data["results"]:
                 yield r
-            next = json_data["next"]
+            next_page = json_data["next"]
+
+    def search_pulses(self, query, limit=20):
+        """
+        Get all pulses with text matching `query`.
+        :param query: The text to search for
+        :param limit: The page size to retrieve in a single request
+        :return: the consolidated set of pulses for the user
+        """
+        pulses = []
+        next_page = self.create_url(SEARCH_PULSES, q=query, limit=limit)
+        while next_page:
+            json_data = self.get(next_page)
+            for r in json_data["results"]:
+                pulses.append(r)
+            next_page = json_data["next"]
+        return pulses
 
     def get_all_indicators(self, indicator_types=IndicatorTypes.all_types):
         """
@@ -162,10 +180,10 @@ class OTXv2(object):
         :return: the consolidated set of pulses for the user
         """
         events = []
-        next = self.create_url(EVENTS, limit=limit, since=mytimestamp)
-        while next:
-            json_data = self.get(next)
+        next_page = self.create_url(EVENTS, limit=limit, since=mytimestamp)
+        while next_page:
+            json_data = self.get(next_page)
             for r in json_data["results"]:
                 events.append(r)
-            next = json_data["next"]
+            next_page = json_data["next"]
         return events

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -211,7 +211,7 @@ class OTXv2(object):
         """
         print ("create_indicator_detail_url indicator_type: {}, indicator: {}, section: {}".format(indicator_type, indicator, section))
         indicator_url = self.create_url(INDICATOR_DETAILS)
-        indicator_url = indicator_url + "{indicator_type}/{indicator}/{section}".format(indicator_type=indicator_type.name,
+        indicator_url = indicator_url + "{indicator_type}/{indicator}/{section}".format(indicator_type=indicator_type.slug,
                                                                                         indicator=indicator,
                                                                                         section=section)
         return indicator_url

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -97,7 +97,10 @@ class OTXv2(object):
         method = "POST"
         request.get_method = lambda: method
         if body:
-            request.add_data(json.dumps(body))
+            try:  # python2
+                request.add_data(json.dumps(body))
+            except AttributeError as ae:  # python3
+                request.data = json.dumps(body).encode('utf-8')
         try:
             response = urlopen(request)
             data = response.read().decode('utf-8')

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -9,7 +9,7 @@ API_V1_ROOT = "{}/api/v1"                                                   # AP
 SUBSCRIBED = "{}/pulses/subscribed".format(API_V1_ROOT)                     # pulse subscriptions
 EVENTS = "{}/pulses/events".format(API_V1_ROOT)                             # events (user actions)
 SEARCH_PULSES = "{}/search/pulses".format(API_V1_ROOT)                      # search pulses
-SEARCH_USERS = "{}/search/users".format(API_V1_ROOT)                                     # search users
+SEARCH_USERS = "{}/search/users".format(API_V1_ROOT)                        # search users
 PULSE_DETAILS = "{}/pulses/".format(API_V1_ROOT)                            # pulse meta data
 PULSE_INDICATORS = PULSE_DETAILS + "indicators"                             # pulse indicators
 PULSE_CREATE = "{}/pulses/create".format(API_V1_ROOT)                       # create pulse
@@ -293,7 +293,7 @@ class OTXv2(object):
         results = []
         next_page_url = url
         additional_fields = {}
-        while next_page_url and max_results:
+        while next_page_url and len(results) < max_results:
             json_data = self.get(next_page_url)
             max_results -= len(json_data.get('results'))
             for r in json_data.pop("results"):
@@ -302,7 +302,7 @@ class OTXv2(object):
             json_data.pop('previous', '')
             if json_data.items():
                 additional_fields.update(json_data)
-        resource = {"results": results}
+        resource = {"results": results[:max_results]}
         resource.update(additional_fields)
         return resource
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ OTX Direct Connect agents provide a way to automatically update your security in
 
 
 # OTX DirectConnect Python SDK
+[![Build Status](https://travis-ci.org/AlienVault-Labs/OTX-Python-SDK.svg)](https://travis-ci.org/AlienVault-Labs/OTX-Python-SDK)
 OTX DirectConnect provides a mechanism to automatically pull indicators of compromise from the Open Threat Exchange portal into your environment.  The DirectConnect API provides access to all _Pulses_ that you have subscribed to in Open Threat Exchange (https://otx.alienvault.com).
 
 1. Clone this repo

--- a/howto_use_python_otx_api.ipynb
+++ b/howto_use_python_otx_api.ipynb
@@ -1,19 +1,33 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using the OTX-Python-SDK"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API Key Configuration"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 24,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "from OTXv2 import OTXv2"
+    "from OTXv2 import OTXv2, IndicatorTypes"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -24,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -35,9 +49,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 7,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -48,18 +62,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Replace YOUR_KEY with your OTX API key. You can find it in your settings page https://otx.alienvault.com/settings"
+    "Replace YOUR_KEY with your OTX API key. You can find it on your settings page https://otx.alienvault.com/settings."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The getall() method downloads all the OTX pulses and their assocciated indicators of compromise (IOCs) from your account. This includes all of the following:  \n",
-    "- OTX pulses to which you subscribed through the web UI\n",
-    "- Pulses created by OTX users to whom you subscribe\n",
-    "- OTX pulses you created. \n",
-    "If this is the first time you are using your account, the download includes all pulses created by AlienVault. All users are subscribed to these by default."
+    "## Subscriptions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The getall() method accesses your subscriptions.  It downloads all the OTX pulses and their assocciated indicators of compromise (IOCs) from your account. This includes:  \n",
+    "- All pulses you subscribe to directly\n",
+    "- All pulses by users you subscribe to\n",
+    "- OTX pulses you created (including private pulses)\n",
+    "If this is the first time you are using your account, the download includes all pulses created by AlienVault. All users are subscribed to the AlienVault user by default."
    ]
   },
   {
@@ -99,14 +120,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's list a few pulses"
+    "Let's list a few pulses:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [
     {
@@ -293,7 +315,8 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": false
    },
    "outputs": [
     {
@@ -851,7 +874,7 @@
     "- indicator: The IOC\n",
     "- indicator_type: Type of indicator\n",
     "\n",
-    "The following Indicator Types are supported:"
+    "The following Indicator Types are supported (also defined in IndicatorTypes.py):"
    ]
   },
   {
@@ -939,7 +962,8 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [
     {
@@ -1099,6 +1123,13 @@
    ],
    "source": [
     "mtime"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Events"
    ]
   },
   {
@@ -1465,10 +1496,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- \"id\": <id of this event>,\n",
-    "- \"action\" : \"[subscribe | unsubscribe | delete]\", // Currently supports subscribe / unsubscribe events for users and pulses and delete events for pulses\n",
-    "- \"object_type\" : \"[pulse | user]\", // Currently supports events for pulse and user objects\n",
-    "- \"object_id\" : \"<pulse id | author id>\", // Used if end user system needs to lookup objects (e.g. to remove them from - system, they would remove all pulses by author_id or an individual pulse by pulse \"id\"\n",
+    "- id: object id of this event.  Unique reference identifier\n",
+    "- action : \"[subscribe | unsubscribe | delete]\", Currently supports subscribe / unsubscribe events for users and pulses and delete events for pulses\n",
+    "- object_type : \"[pulse | user]\", // Currently supports events for pulse and user objects\n",
+    "- object_id : \"[pulse id | author id]\", // Unique id can be used to lookup pulses and users (e.g. to remove them from  system, they would remove all pulses by author_id or an individual pulse by pulse \"id\".\n",
     "\"created\" : <timestamp of event>"
    ]
   },
@@ -1478,6 +1509,746 @@
    "source": [
     "When developing an application, you must decide how you want to handle different types of events. For instance, if one OTX user unsubscribes from another user, do you want to delete the IOCs the second user contributed from your application? How do you plan to reconcile the data on the server versus the data in your application?\n",
     "The same question comes up when users delete a pulse."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Search and get Pulse by ID"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The OTX API allows you to search for pulses and users by keyword.  This allows you to obtain pulses that you're not (yet) subscribed to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pulses = otx.search_pulses(\"Russian\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>TLP</th>\n",
+       "      <th>author.avatar_url</th>\n",
+       "      <th>author.id</th>\n",
+       "      <th>author.username</th>\n",
+       "      <th>cloned_from</th>\n",
+       "      <th>comment_count</th>\n",
+       "      <th>created</th>\n",
+       "      <th>description</th>\n",
+       "      <th>downvotes_count</th>\n",
+       "      <th>export_count</th>\n",
+       "      <th>...</th>\n",
+       "      <th>modified_text</th>\n",
+       "      <th>name</th>\n",
+       "      <th>public</th>\n",
+       "      <th>references</th>\n",
+       "      <th>subscriber_count</th>\n",
+       "      <th>tags</th>\n",
+       "      <th>upvotes_count</th>\n",
+       "      <th>validator_count</th>\n",
+       "      <th>vote</th>\n",
+       "      <th>votes_count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>green</td>\n",
+       "      <td>https://otx20-web-media.s3.amazonaws.com/media...</td>\n",
+       "      <td>55003d1d13432a7f96c2be0a</td>\n",
+       "      <td>AlienVault</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2016-05-18T14:52:41.117000</td>\n",
+       "      <td>Operation Groundbait (Russian: Прикормка, Prik...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>14</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2 days ago</td>\n",
+       "      <td>Operation Groundbait: Analysis of a surveillan...</td>\n",
+       "      <td>True</td>\n",
+       "      <td>[http://www.welivesecurity.com/wp-content/uplo...</td>\n",
+       "      <td>14655</td>\n",
+       "      <td>[Groundbait, russia, ukraine, Prikormka, surve...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>green</td>\n",
+       "      <td>https://otx20-web-media.s3.amazonaws.com/media...</td>\n",
+       "      <td>55bb3ec74637f238607a9c69</td>\n",
+       "      <td>bartblaze</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2016-05-10T10:48:53.586000</td>\n",
+       "      <td>A new ransomware called Enigma was discovered ...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>...</td>\n",
+       "      <td>9 days ago</td>\n",
+       "      <td>Enigma ransomware</td>\n",
+       "      <td>True</td>\n",
+       "      <td>[http://www.bleepingcomputer.com/news/security...</td>\n",
+       "      <td>138</td>\n",
+       "      <td>[enigma, enigma ransomware]</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>green</td>\n",
+       "      <td>https://otx20-web-media.s3.amazonaws.com/media...</td>\n",
+       "      <td>55003d1d13432a7f96c2be0a</td>\n",
+       "      <td>AlienVault</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2016-05-10T16:03:54.294000</td>\n",
+       "      <td>Recently the Mobile Malware Research Team of I...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>19</td>\n",
+       "      <td>...</td>\n",
+       "      <td>9 days ago</td>\n",
+       "      <td>Android Malware Clicker.G!Gen Found on Google ...</td>\n",
+       "      <td>True</td>\n",
+       "      <td>[https://blogs.mcafee.com/mcafee-labs/android-...</td>\n",
+       "      <td>14653</td>\n",
+       "      <td>[google play, trojan, android, mobile, malware...</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>green</td>\n",
+       "      <td>https://otx20-web-media.s3.amazonaws.com/media...</td>\n",
+       "      <td>5721dc5ca08845015a81565c</td>\n",
+       "      <td>Umbra00</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2016-05-03T11:11:14.151000</td>\n",
+       "      <td>Attempting to append the pot. analysis of the ...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>17 days ago</td>\n",
+       "      <td>Remote Code Execution Attempt / auto append file</td>\n",
+       "      <td>True</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>21</td>\n",
+       "      <td>[R.TXT, ghc.ru, rst.void.ru, 1dt.w0lf]</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>green</td>\n",
+       "      <td>https://otx20-web-media.s3.amazonaws.com/media...</td>\n",
+       "      <td>55bb3ec74637f238607a9c69</td>\n",
+       "      <td>bartblaze</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2016-04-29T16:32:35.621000</td>\n",
+       "      <td>BrLock was found on April 18, 2016, but the ex...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>...</td>\n",
+       "      <td>20 days ago</td>\n",
+       "      <td>BrLock ransomware</td>\n",
+       "      <td>True</td>\n",
+       "      <td>[https://www.proofpoint.com/us/threat-insight/...</td>\n",
+       "      <td>138</td>\n",
+       "      <td>[brlock, brlock ransomware]</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 36 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     TLP                                  author.avatar_url  \\\n",
+       "0  green  https://otx20-web-media.s3.amazonaws.com/media...   \n",
+       "1  green  https://otx20-web-media.s3.amazonaws.com/media...   \n",
+       "2  green  https://otx20-web-media.s3.amazonaws.com/media...   \n",
+       "3  green  https://otx20-web-media.s3.amazonaws.com/media...   \n",
+       "4  green  https://otx20-web-media.s3.amazonaws.com/media...   \n",
+       "\n",
+       "                  author.id author.username cloned_from  comment_count  \\\n",
+       "0  55003d1d13432a7f96c2be0a      AlienVault        None              0   \n",
+       "1  55bb3ec74637f238607a9c69       bartblaze        None              0   \n",
+       "2  55003d1d13432a7f96c2be0a      AlienVault        None              0   \n",
+       "3  5721dc5ca08845015a81565c         Umbra00        None              0   \n",
+       "4  55bb3ec74637f238607a9c69       bartblaze        None              0   \n",
+       "\n",
+       "                      created  \\\n",
+       "0  2016-05-18T14:52:41.117000   \n",
+       "1  2016-05-10T10:48:53.586000   \n",
+       "2  2016-05-10T16:03:54.294000   \n",
+       "3  2016-05-03T11:11:14.151000   \n",
+       "4  2016-04-29T16:32:35.621000   \n",
+       "\n",
+       "                                         description  downvotes_count  \\\n",
+       "0  Operation Groundbait (Russian: Прикормка, Prik...                0   \n",
+       "1  A new ransomware called Enigma was discovered ...                0   \n",
+       "2  Recently the Mobile Malware Research Team of I...                0   \n",
+       "3  Attempting to append the pot. analysis of the ...                0   \n",
+       "4  BrLock was found on April 18, 2016, but the ex...                0   \n",
+       "\n",
+       "   export_count     ...       modified_text  \\\n",
+       "0            14     ...         2 days ago    \n",
+       "1             3     ...         9 days ago    \n",
+       "2            19     ...         9 days ago    \n",
+       "3             1     ...        17 days ago    \n",
+       "4             3     ...        20 days ago    \n",
+       "\n",
+       "                                                name  public  \\\n",
+       "0  Operation Groundbait: Analysis of a surveillan...    True   \n",
+       "1                                  Enigma ransomware    True   \n",
+       "2  Android Malware Clicker.G!Gen Found on Google ...    True   \n",
+       "3   Remote Code Execution Attempt / auto append file    True   \n",
+       "4                                  BrLock ransomware    True   \n",
+       "\n",
+       "                                          references  subscriber_count  \\\n",
+       "0  [http://www.welivesecurity.com/wp-content/uplo...             14655   \n",
+       "1  [http://www.bleepingcomputer.com/news/security...               138   \n",
+       "2  [https://blogs.mcafee.com/mcafee-labs/android-...             14653   \n",
+       "3                                                 []                21   \n",
+       "4  [https://www.proofpoint.com/us/threat-insight/...               138   \n",
+       "\n",
+       "                                                tags  upvotes_count  \\\n",
+       "0  [Groundbait, russia, ukraine, Prikormka, surve...              2   \n",
+       "1                        [enigma, enigma ransomware]              0   \n",
+       "2  [google play, trojan, android, mobile, malware...              3   \n",
+       "3             [R.TXT, ghc.ru, rst.void.ru, 1dt.w0lf]              0   \n",
+       "4                        [brlock, brlock ransomware]              1   \n",
+       "\n",
+       "   validator_count  vote  votes_count  \n",
+       "0                0     1            2  \n",
+       "1                0     0            0  \n",
+       "2                0     1            3  \n",
+       "3                0     0            0  \n",
+       "4                0     0            1  \n",
+       "\n",
+       "[5 rows x 36 columns]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "json_normalize(pulses[\"results\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's say we're interested in viewing the full details (including indicators) from one of our search results.  For example maybe we're interested in the Enigma Ransomware:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pulse_id = pulses[\"results\"][1][\"id\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "pulse_details = otx.get_pulse_details(pulse_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>TLP</th>\n",
+       "      <th>author_name</th>\n",
+       "      <th>created</th>\n",
+       "      <th>description</th>\n",
+       "      <th>id</th>\n",
+       "      <th>indicators</th>\n",
+       "      <th>modified</th>\n",
+       "      <th>name</th>\n",
+       "      <th>public</th>\n",
+       "      <th>references</th>\n",
+       "      <th>revision</th>\n",
+       "      <th>tags</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>green</td>\n",
+       "      <td>bartblaze</td>\n",
+       "      <td>2016-05-10T10:48:53.586000</td>\n",
+       "      <td>A new ransomware called Enigma was discovered ...</td>\n",
+       "      <td>5731bc95452c27015dad07e0</td>\n",
+       "      <td>[{u'indicator': u'e8c8417f335cd2766ad1570de8b1...</td>\n",
+       "      <td>2016-05-11T12:17:46.494000</td>\n",
+       "      <td>Enigma ransomware</td>\n",
+       "      <td>True</td>\n",
+       "      <td>[http://www.bleepingcomputer.com/news/security...</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>[enigma, enigma ransomware]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     TLP author_name                     created  \\\n",
+       "0  green   bartblaze  2016-05-10T10:48:53.586000   \n",
+       "\n",
+       "                                         description  \\\n",
+       "0  A new ransomware called Enigma was discovered ...   \n",
+       "\n",
+       "                         id  \\\n",
+       "0  5731bc95452c27015dad07e0   \n",
+       "\n",
+       "                                          indicators  \\\n",
+       "0  [{u'indicator': u'e8c8417f335cd2766ad1570de8b1...   \n",
+       "\n",
+       "                     modified               name public  \\\n",
+       "0  2016-05-11T12:17:46.494000  Enigma ransomware   True   \n",
+       "\n",
+       "                                          references  revision  \\\n",
+       "0  [http://www.bleepingcomputer.com/news/security...       2.0   \n",
+       "\n",
+       "                          tags  \n",
+       "0  [enigma, enigma ransomware]  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "json_normalize(pulse_details)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Indicator details"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's investigate an indicator included in the Enigma Ransomware pulse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "indicator = pulse_details[\"indicators\"][4][\"indicator\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "indicator_details = otx.get_indicator_details_full(IndicatorTypes.IPv4, indicator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Indicator details are divided into sections for convenience:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['malware', 'passive_dns', 'url_list', 'general', 'reputation', 'geo']"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "indicator_details.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>actual_size</th>\n",
+       "      <th>full_size</th>\n",
+       "      <th>has_next</th>\n",
+       "      <th>limit</th>\n",
+       "      <th>page_num</th>\n",
+       "      <th>paged</th>\n",
+       "      <th>url_list</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>22</td>\n",
+       "      <td>22</td>\n",
+       "      <td>True</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1</td>\n",
+       "      <td>True</td>\n",
+       "      <td>[{u'domain': u'', u'url': u'http://82.194.84.1...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   actual_size  full_size has_next  limit  page_num paged  \\\n",
+       "0           22         22     True     10         1  True   \n",
+       "\n",
+       "                                            url_list  \n",
+       "0  [{u'domain': u'', u'url': u'http://82.194.84.1...  "
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "json_normalize(indicator_details[\"url_list\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>address</th>\n",
+       "      <th>asset_type</th>\n",
+       "      <th>first</th>\n",
+       "      <th>flag_title</th>\n",
+       "      <th>flag_url</th>\n",
+       "      <th>hostname</th>\n",
+       "      <th>indicator_link</th>\n",
+       "      <th>last</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>82.194.84.120</td>\n",
+       "      <td>domain</td>\n",
+       "      <td>2013-08-29 14:59:51</td>\n",
+       "      <td>Spain</td>\n",
+       "      <td>/static/img/flags/es.png</td>\n",
+       "      <td>comitres.net</td>\n",
+       "      <td>/indicator/domain/comitres.net</td>\n",
+       "      <td>2014-07-24 01:04:39</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>82.194.84.120</td>\n",
+       "      <td>domain</td>\n",
+       "      <td>2013-10-09 18:09:10</td>\n",
+       "      <td>Spain</td>\n",
+       "      <td>/static/img/flags/es.png</td>\n",
+       "      <td>apamac.net</td>\n",
+       "      <td>/indicator/domain/apamac.net</td>\n",
+       "      <td>2013-12-16 15:42:58</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>82.194.84.120</td>\n",
+       "      <td>domain</td>\n",
+       "      <td>2013-08-31 15:02:04</td>\n",
+       "      <td>Spain</td>\n",
+       "      <td>/static/img/flags/es.png</td>\n",
+       "      <td>estudio-danza-camargo.com</td>\n",
+       "      <td>/indicator/domain/estudio-danza-camargo.com</td>\n",
+       "      <td>2013-08-31 15:02:04</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         address asset_type                first flag_title  \\\n",
+       "0  82.194.84.120     domain  2013-08-29 14:59:51      Spain   \n",
+       "1  82.194.84.120     domain  2013-10-09 18:09:10      Spain   \n",
+       "2  82.194.84.120     domain  2013-08-31 15:02:04      Spain   \n",
+       "\n",
+       "                   flag_url                   hostname  \\\n",
+       "0  /static/img/flags/es.png               comitres.net   \n",
+       "1  /static/img/flags/es.png                 apamac.net   \n",
+       "2  /static/img/flags/es.png  estudio-danza-camargo.com   \n",
+       "\n",
+       "                                indicator_link                 last  \n",
+       "0               /indicator/domain/comitres.net  2014-07-24 01:04:39  \n",
+       "1                 /indicator/domain/apamac.net  2013-12-16 15:42:58  \n",
+       "2  /indicator/domain/estudio-danza-camargo.com  2013-08-31 15:02:04  "
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "json_normalize(indicator_details[\"passive_dns\"].get('passive_dns'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Indicator details are not available for all supported indicator types.  IndicatorTypes.supported_api_types contains a list of the indicator types you can use with get_indicator_details_by_section and get_indicator_details_full. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create pulse"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can create new pulses using the create_pulse function.  A name string is required.  Public boolean is also required but will be set True if not provided:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "indicators = [{\"indicator\": \"82.194.84.121\", \"description\":\"\", \"type\": \"IPv4\"}, {\"indicator\": \"82.194.84.122\", \"description\":\"\", \"type\": \"IPv4\"}]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "new_pulse = otx.create_pulse(name=\"IPy Notebook Test\", indicators=indicators, public=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>TLP</th>\n",
+       "      <th>active</th>\n",
+       "      <th>author_id</th>\n",
+       "      <th>author_name</th>\n",
+       "      <th>cloned_from</th>\n",
+       "      <th>comments_count</th>\n",
+       "      <th>created</th>\n",
+       "      <th>description</th>\n",
+       "      <th>downvotes</th>\n",
+       "      <th>downvotes_count</th>\n",
+       "      <th>...</th>\n",
+       "      <th>subscribers</th>\n",
+       "      <th>subscribers_count</th>\n",
+       "      <th>tags</th>\n",
+       "      <th>tags_count</th>\n",
+       "      <th>unsubscribed_users</th>\n",
+       "      <th>upvotes</th>\n",
+       "      <th>upvotes_count</th>\n",
+       "      <th>validators</th>\n",
+       "      <th>validators_count</th>\n",
+       "      <th>votes_count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>green</td>\n",
+       "      <td>True</td>\n",
+       "      <td>14830</td>\n",
+       "      <td>hilaryclintonsemailserver</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2016-05-20T16:25:59.670399</td>\n",
+       "      <td></td>\n",
+       "      <td>[]</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>0</td>\n",
+       "      <td>[]</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1 rows × 38 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     TLP active  author_id                author_name cloned_from  \\\n",
+       "0  green   True      14830  hilaryclintonsemailserver        None   \n",
+       "\n",
+       "   comments_count                     created description downvotes  \\\n",
+       "0               0  2016-05-20T16:25:59.670399                    []   \n",
+       "\n",
+       "   downvotes_count     ...      subscribers subscribers_count tags tags_count  \\\n",
+       "0                0     ...               []                 0   []          0   \n",
+       "\n",
+       "   unsubscribed_users upvotes upvotes_count validators validators_count  \\\n",
+       "0                  []      []             0         []                0   \n",
+       "\n",
+       "  votes_count  \n",
+       "0           0  \n",
+       "\n",
+       "[1 rows x 38 columns]"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "json_normalize(new_pulse)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following fields can be passed into create_pulse:\n",
+    "- name(string, required) pulse name\n",
+    "- public(boolean, required) long form description of threat\n",
+    "- description(string) long form description of threat\n",
+    "- tlp(string, white/green/amber/red) Traffic Light Protocol level for threat sharing\n",
+    "- tags(list of strings) short keywords to associate with your pulse\n",
+    "- references(list of strings, preferably URLs) external references for this threat\n",
+    "- indicators(list of objects) IOCs to include in pulse"
    ]
   }
  ],

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(name='OTXv2',
       author='AlienVault Team',
       author_email='otx@alienvault.com',
       url='https://github.com/AlienVault-Labs/OTX-Python-SDK',
-      py_modules=['OTXv2','IndicatorTypes'],
+      download_url='https://github.com/AlienVault-Labs/OTX-Python-SDK/tarball/1.1.0',
+      py_modules=['OTXv2', 'IndicatorTypes'],
       install_requires=['simplejson']
       )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -265,16 +265,19 @@ class TestPulseCreate(TestOTXv2):
             {'indicator': "14c04f88dc97aef3e9b516ef208a2bf5", 'type': IndicatorTypes.FILE_HASH_MD5},
             {'indicator': "48e04cb52f1077b5f5aab75baff6c27b0ee4ade1", 'type': IndicatorTypes.FILE_HASH_SHA1},
             {'indicator': "7522bc3e366c19ab63381bacd0f03eb09980ecb915ada08ae76d8c3e538600de", 'type': IndicatorTypes.FILE_HASH_SHA256},
-            {'indicator': "a060fe925aa888053010d1e195ef823a", 'type': IndicatorTypes.FILE_HASH_IMPHASH, "description": "Gen:Variant.Strictor.24454"},
+            {'indicator': "a060fe925aa888053010d1e195ef823a", 'type': IndicatorTypes.FILE_HASH_IMPHASH},
             {'indicator': "\sonas\share\samples\14\c0\4f\88\14c04f88dc97aef3e9b516ef208a2bf5", 'type': IndicatorTypes.FILE_PATH},
         ]
+        name = "Pyclient-unittests-" + generate_rand_string(8, charset=string.hexdigits).lower()
         for indicator in indicator_list:
             validated_indicator = self.otx.validate_indicator(indicator.get('indicator', ''), indicator.get('type'))
             self.assertTrue('success' in validated_indicator.get('status', ''))
             validated_indicator_list.append(validated_indicator)
-        print("test_create_pulse_with_indicators: finished validating indicators, submitting pulse....")
-        name = "Pyclient-unittests-" + generate_rand_string(8, charset=string.hexdigits).lower()
-        self.otx.create_pulse(name=name, public=False, indicators=validated_indicator_list)
+        print("test_create_pulse_with_indicators: finished validating indicators.\nsubmitting pulse: {}".format({"name": name, "indicators": validated_indicator_list}))
+        response = self.otx.create_pulse(name=name, public=False, indicators=validated_indicator_list)
+        self.assertTrue(response.get('name', '') == name)
+        self.assertTrue(len(response.get('indicators', [])) == len(validated_indicator_list))
+        return
 
 
 class TestPulseCreateInvalidKey(TestOTXv2):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from utils import generate_rand_string
 from OTXv2 import OTXv2, InvalidAPIKey
 import IndicatorTypes
 
-ALIEN_API_APIKEY = os.getenv('X_OTX_API_KEY', "db91e98e6dcac6303bd1522d3542f91fcb4be176ea262ecd892d39e0d82a218b")
+ALIEN_API_APIKEY = os.getenv('X_OTX_API_KEY', "mysecretkey")
 STRP_TIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,7 +74,10 @@ class TestSubscriptions(TestOTXv2):
             print(u"test_getsince next pulse: {0}".format(pulse.get('name', '')))
             pulse_modified = pulse.get('modified', None)
             self.assertIsNotNone(pulse_modified)
-            pulse_modified_dt = datetime.datetime.strptime(pulse_modified, STRP_TIME_FORMAT)
+            try:
+                pulse_modified_dt = datetime.datetime.strptime(pulse_modified, STRP_TIME_FORMAT)
+            except ValueError:
+                pulse_modified_dt = datetime.datetime.strptime(pulse_modified, '%Y-%m-%dT%H:%M:%S')
             self.assertGreaterEqual(pulse_modified_dt, three_months_dt)
 
     def test_getsince_iter(self):
@@ -87,7 +90,10 @@ class TestSubscriptions(TestOTXv2):
             self.assertTrue(pulse.get('name', None))
             pulse_modified = pulse.get('modified', None)
             self.assertIsNotNone(pulse_modified)
-            pulse_modified_dt = datetime.datetime.strptime(pulse_modified, STRP_TIME_FORMAT)
+            try:
+                pulse_modified_dt = datetime.datetime.strptime(pulse_modified, STRP_TIME_FORMAT)
+            except ValueError:
+                pulse_modified_dt = datetime.datetime.strptime(pulse_modified, '%Y-%m-%dT%H:%M:%S')
             self.assertGreaterEqual(pulse_modified_dt, three_months_dt)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,16 +1,22 @@
 import unittest
 import datetime
 import os
+import pprint
+import string
 
 from utils import generate_rand_string
 from OTXv2 import OTXv2, InvalidAPIKey
-from IndicatorTypes import IPv4
+import IndicatorTypes
 
-ALIEN_API_APIKEY = os.getenv('X_OTX_API_KEY', "mysecretkey")
+ALIEN_API_APIKEY = os.getenv('X_OTX_API_KEY', "db91e98e6dcac6303bd1522d3542f91fcb4be176ea262ecd892d39e0d82a218b")
 STRP_TIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 
 
+# Class names should start with "Test"
 class TestOTXv2(unittest.TestCase):
+    """
+    Base class configure API Key to use on a per test basis.
+    """
     def setUp(self, **kwargs):
         provided_key = kwargs.get('api_key', '')
         if provided_key:
@@ -21,6 +27,9 @@ class TestOTXv2(unittest.TestCase):
 
 
 class TestSubscriptionsInvalidKey(TestOTXv2):
+    """
+    Confirm InvalidAPIKey class is raised for API Key failures
+    """
     def setUp(self, **kwargs):
         super(TestSubscriptionsInvalidKey, self).setUp(**{'api_key': generate_rand_string(length=64)})
 
@@ -30,6 +39,9 @@ class TestSubscriptionsInvalidKey(TestOTXv2):
 
 
 class TestSubscriptions(TestOTXv2):
+    """
+    Confirm that given a valid API Key, we can obtain threat intelligence subscriptions.
+    """
     def setUp(self, **kwargs):
         super(TestSubscriptions, self).setUp(**{'api_key': ALIEN_API_APIKEY})
 
@@ -51,6 +63,7 @@ class TestSubscriptions(TestOTXv2):
         pulse_gen = self.otx.getall_iter()
         self.assertIsNotNone(pulse_gen)
         for pulse in pulse_gen:
+            print(u"test_getall_iter next pulse: {0}".format(pulse.get('name', '')))
             self.assertTrue(pulse.get('name', None))
 
     def test_getsince(self):
@@ -58,6 +71,7 @@ class TestSubscriptions(TestOTXv2):
         three_months_timestamp = three_months_dt.isoformat()
         pulses = self.otx.getsince(three_months_timestamp, limit=9999)
         for pulse in pulses:
+            print(u"test_getsince next pulse: {0}".format(pulse.get('name', '')))
             pulse_modified = pulse.get('modified', None)
             self.assertIsNotNone(pulse_modified)
             pulse_modified_dt = datetime.datetime.strptime(pulse_modified, STRP_TIME_FORMAT)
@@ -69,6 +83,7 @@ class TestSubscriptions(TestOTXv2):
         pulse_gen = self.otx.getsince_iter(three_months_timestamp, limit=9999)
         self.assertIsNotNone(pulse_gen)
         for pulse in pulse_gen:
+            print(u"test_getsince_iter next pulse: {0}".format(pulse.get('name', '')))
             self.assertTrue(pulse.get('name', None))
             pulse_modified = pulse.get('modified', None)
             self.assertIsNotNone(pulse_modified)
@@ -80,16 +95,26 @@ class TestSearch(TestOTXv2):
     def setUp(self, **kwargs):
         super(TestSearch, self).setUp(**{'api_key': ALIEN_API_APIKEY})
 
-    def test_search(self):
-        pulses = self.otx.search_pulses("malware", limit=9999)
+    def test_search_pulses_simple(self):
+        pulses, additional_data = self.otx.search_pulses("malware", limit=9)
         self.assertIsNotNone(pulses)
         self.assertTrue(len(pulses) > 0)
-        most_recent = pulses[0]
-        self.assertIsNotNone(most_recent.get('modified', None))
-        self.assertIsNotNone(most_recent.get('author', None))
-        self.assertIsNotNone(most_recent.get('id', None))
-        self.assertIsNotNone(most_recent.get('tags', None))
-        self.assertIsNotNone(most_recent.get('references', None))
+        for pulse in pulses:
+            print(u"test_search_pulses_simple next pulse: {0}".format(pulse.get('name', '')))
+            self.assertIsNotNone(pulse.get('modified', None))
+            self.assertIsNotNone(pulse.get('author', None))
+            self.assertIsNotNone(pulse.get('id', None))
+            self.assertIsNotNone(pulse.get('tags', None))
+            self.assertIsNotNone(pulse.get('references', None))
+        self.assertTrue(additional_data.get('users_count', -1) >= 0)
+        self.assertIsNotNone(additional_data.get('exact_match'))
+
+    def test_exact_match_domain(self):
+        pulses, additional_data = self.otx.search_pulses("malware.org", limit=9999)
+        self.assertIsNotNone(pulses)
+        print("test_exact_match_domain additional data for malware.org:")
+        pprint.pprint(additional_data)
+        self.assertTrue(additional_data.get('exact_match', -1))
 
 
 class TestEvents(TestOTXv2):
@@ -121,14 +146,104 @@ class TestIndicatorTypes(TestOTXv2):
             self.assertIsNotNone(indicator.get('description', None))
 
     def test_get_all_ipv4_indicators(self):
-        ipv4_type_list = [IPv4]
+        ipv4_type_list = [IndicatorTypes.IPv4]
         ipv4_indicator_gen = self.otx.get_all_indicators(indicator_types=ipv4_type_list)
         for indicator in ipv4_indicator_gen:
             self.assertIsNotNone(indicator)
             self.assertIsNotNone(indicator.get('type', None))
             self.assertIsNotNone(indicator.get('indicator', None))
             self.assertIsNotNone(indicator.get('description', None))
-            self.assertTrue(indicator.get('type', '') == IPv4.name)
+            self.assertTrue(indicator.get('type', '') == IndicatorTypes.IPv4.name)
+
+
+class TestPulseDetails(TestOTXv2):
+    def setUp(self, **kwargs):
+        super(TestPulseDetails, self).setUp(**{'api_key': ALIEN_API_APIKEY})
+
+    def test_get_pulse_details(self):
+        # get a pulse from search to use as testcase
+        pulses, additional_data = self.otx.search_pulses("malware", limit=10, page=1)
+        pulse = pulses[0]
+        pulse_id = pulse.get('id', '')
+        meta_data = self.otx.get_pulse_details(pulse_id=pulse_id)
+        print("meta data:")
+        pprint.pprint(meta_data)
+        self.assertIsNotNone(meta_data)
+        self.assertTrue('author_name' in meta_data.keys())
+        self.assertTrue('name' in meta_data.keys())
+        self.assertTrue('references' in meta_data.keys())
+        self.assertTrue('tags' in meta_data.keys())
+        self.assertTrue('indicators' in meta_data.keys())
+
+    def test_get_pulse_indicators(self):
+        pulses, additional_data = self.otx.search_pulses("malware", limit=10, page=1)
+        pulse = pulses[0]
+        pulse_id = pulse.get('id', '')
+        indicators = self.otx.get_pulse_indicators(pulse_id=pulse_id)
+        self.assertIsNotNone(indicators)
+        self.assertTrue('count' in indicators.keys())
+        self.assertTrue('results' in indicators.keys())
+        results = indicators.get('results', [])
+        for indicator in results:
+            print("next indicator:")
+            pprint.pprint(indicator)
+            self.assertTrue(indicator.get('indicator', '') != '')
+            self.assertTrue(indicator.get('type', '') != '')
+
+
+class TestIndicatorDetails(TestOTXv2):
+    def setUp(self, **kwargs):
+        super(TestIndicatorDetails, self).setUp(**{'api_key': ALIEN_API_APIKEY})
+
+    def test_get_indicator_details_IPv4_by_section(self):
+        print("test_get_indicator_details_IPv4_by_section")
+        for section in IndicatorTypes.IPv4.sections:
+            print("next section: {0}".format(section))
+            section_details = self.otx.get_indicator_details_by_section(IndicatorTypes.IPv4, "69.73.130.198", section)
+            print(u"section: {0}".format(section))
+            pprint.pprint(section_details)
+            self.assertTrue(True)
+
+    def test_get_indicator_details_IPv4_full(self):
+        print("test_get_indicator_details_IPv4_full")
+        full_details = self.otx.get_full_indicator_details(IndicatorTypes.IPv4, "69.73.130.198")
+        print("details: ")
+        pprint.pprint(full_details)
+
+
+class TestPulseCreate(TestOTXv2):
+    def setUp(self, **kwargs):
+        super(TestPulseCreate, self).setUp(**{'api_key': ALIEN_API_APIKEY})
+
+    def test_create_pulse_simple(self):
+        name = "Pyclient-unittests-" + generate_rand_string(8, charset=string.hexdigits).lower()
+        print("test_create_pulse_simple submitting pulse: " + name)
+        response = self.otx.create_pulse(name=name,
+                                         public=False,
+                                         indicators=[],
+                                         tags=[],
+                                         references=[])
+        self.assertIsNotNone(response)
+
+    def test_create_pulse_no_name(self):
+        print("test_create_pulse_no_name submitting nameless pulse")
+        with self.assertRaises(ValueError):
+            self.otx.create_pulse(**{})
+
+
+class TestPulseCreateInvalidKey(TestOTXv2):
+    def setUp(self, **kwargs):
+        super(TestPulseCreateInvalidKey, self).setUp(**{'api_key': "ALIEN_API_APIKEY"})
+
+    def test_create_pulse_invalid_key(self):
+        name = "Pyclient-unittests-" + generate_rand_string(8, charset=string.hexdigits).lower()
+        print("test_create_pulse_simple submitting pulse: " + name)
+        with self.assertRaises(InvalidAPIKey):
+            self.otx.create_pulse(name=name,
+                                  public=False,
+                                  indicators=[],
+                                  tags=[],
+                                  references=[])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -38,7 +38,6 @@ class TestSubscriptions(TestOTXv2):
         self.assertIsNotNone(pulses)
         self.assertTrue(len(pulses) > 0)
         most_recent = pulses[0]
-        print "most recent pulse: {0}".format(most_recent.get('name', ''))
         self.assertIsNotNone(most_recent.get('id', None))
         self.assertIsNotNone(most_recent.get('name', None))
         self.assertIsNotNone(most_recent.get('description', None))
@@ -89,7 +88,6 @@ class TestSearch(TestOTXv2):
         self.assertIsNotNone(most_recent.get('modified', None))
         self.assertIsNotNone(most_recent.get('author', None))
         self.assertIsNotNone(most_recent.get('id', None))
-        self.assertIsNotNone(most_recent.get('indicators', None))
         self.assertIsNotNone(most_recent.get('tags', None))
         self.assertIsNotNone(most_recent.get('references', None))
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -223,8 +223,8 @@ class TestIndicatorDetails(TestOTXv2):
 
     def test_get_indicator_details_IPv4_full(self):
         print("test_get_indicator_details_IPv4_full")
-        full_details = self.otx.get_full_indicator_details(IndicatorTypes.IPv4, "69.73.130.198")
-        print("details: ")
+        full_details = self.otx.get_indicator_details_full(IndicatorTypes.IPv4, "69.73.130.198")
+        self.assertTrue(sorted(full_details.keys()) == sorted(IndicatorTypes.IPv4.sections))
         pprint.pprint(full_details)
 
 
@@ -290,7 +290,7 @@ class TestPulseCreate(TestOTXv2):
         ]
         name = "Pyclient-indicators-unittests-" + generate_rand_string(8, charset=string.hexdigits).lower()
         for indicator in indicator_list:
-            validated_indicator = self.otx.validate_indicator(indicator.get('indicator', ''), indicator.get('type'))
+            validated_indicator = self.otx.validate_indicator(indicator.get('type'), indicator.get('indicator', ''))
             self.assertTrue('success' in validated_indicator.get('status', ''))
             validated_indicator_list.append(validated_indicator)
         print("test_create_pulse_with_indicators: finished validating indicators.\nsubmitting pulse: {}".format({"name": name, "indicators": validated_indicator_list}))
@@ -342,7 +342,7 @@ class TestValidateIndicator(TestOTXv2):
         indicator = generate_rand_string(8, charset=string.ascii_letters).lower() + ".com"
         indicator_type = IndicatorTypes.DOMAIN
         print("test_validate_valid_domain submitting (valid-ish) indicator: " + indicator)
-        response = self.otx.validate_indicator(indicator=indicator, indicator_type=indicator_type)
+        response = self.otx.validate_indicator(indicator_type=indicator_type, indicator=indicator)
         print ("test_validate_valid_domain response: {}".format(response))
         self.assertIsNotNone(response)
         self.assertTrue('success' in response.get('status', ''))
@@ -352,7 +352,7 @@ class TestValidateIndicator(TestOTXv2):
         indicator_type = IndicatorTypes.DOMAIN
         print("test_validate_invalid_domain submitting indicator: " + indicator)
         with self.assertRaises(BadRequest):
-            self.otx.validate_indicator(indicator=indicator, indicator_type=indicator_type)
+            self.otx.validate_indicator(indicator_type=indicator_type, indicator=indicator)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,6 @@ import datetime
 import os
 import pprint
 import string
-import types
 
 from utils import generate_rand_string
 from OTXv2 import OTXv2, InvalidAPIKey, BadRequest
@@ -115,7 +114,7 @@ class TestSearch(TestOTXv2):
     def test_exact_match_domain(self):
         res = self.otx.search_pulses("malware.org")
         pulses = res.get('results')
-        self.assertTrue(isinstance(pulses, types.ListType))
+        self.assertTrue(isinstance(pulses, list))
         self.assertTrue(len(pulses) > 0)
         self.assertIsNotNone(pulses)
         print("test_exact_match_domain additional data for malware.org:")
@@ -125,7 +124,7 @@ class TestSearch(TestOTXv2):
     def test_search_users(self):
         res = self.otx.search_users("alien")
         self.assertTrue('results' in res.keys())
-        self.assertTrue(isinstance(res.get('results', ''), types.ListType))
+        self.assertTrue(isinstance(res.get('results', ''), list))
         users = res.get('results')
         first_user = users[0]
         self.assertTrue(first_user.get('username', '') != '')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -87,7 +87,6 @@ class TestEvents(TestOTXv2):
         self.assertIsNotNone(events)
         self.assertTrue(len(events) > 0)
         most_recent = events[0]
-        print "Next event: {0}".format(most_recent.keys())
         self.assertIsNotNone(most_recent.get('action', None))
         self.assertIsNotNone(most_recent.get('created', None))
         self.assertIsNotNone(most_recent.get('id', None))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import dateutil.parser
 
 from utils import generate_rand_string
 from OTXv2 import OTXv2, InvalidAPIKey
+from IndicatorTypes import IPv4
 
 ALIEN_API_APIKEY = "48db25670b590ae34850cb13e25397e1e6cad56f2c4f7bdae75a1121dc76bdd0"
 
@@ -53,15 +54,66 @@ class TestSubscriptions(TestOTXv2):
             self.assertTrue(pulse.get('name', None))
 
     def test_getsince(self):
-        year_ago_dt = (datetime.datetime.now() - datetime.timedelta(days=90))
-        year_ago_timestamp = year_ago_dt.isoformat()
-        pulses = self.otx.getsince(year_ago_timestamp, limit=9999)
+        three_months_dt = (datetime.datetime.now() - datetime.timedelta(days=90))
+        three_months_timestamp = three_months_dt.isoformat()
+        pulses = self.otx.getsince(three_months_timestamp, limit=9999)
         for pulse in pulses:
             pulse_modified = pulse.get('modified', None)
             self.assertIsNotNone(pulse_modified)
             pulse_modified_dt = dateutil.parser.parse(pulse_modified)
-            self.assertGreaterEqual(pulse_modified_dt, year_ago_dt)
+            self.assertGreaterEqual(pulse_modified_dt, three_months_dt)
 
+    def test_getsince_iter(self):
+        three_months_dt = (datetime.datetime.now() - datetime.timedelta(days=90))
+        three_months_timestamp = three_months_dt.isoformat()
+        pulse_gen = self.otx.getsince_iter(three_months_timestamp, limit=9999)
+        self.assertIsNotNone(pulse_gen)
+        for pulse in pulse_gen:
+            self.assertTrue(pulse.get('name', None))
+            pulse_modified = pulse.get('modified', None)
+            self.assertIsNotNone(pulse_modified)
+            pulse_modified_dt = dateutil.parser.parse(pulse_modified)
+            self.assertGreaterEqual(pulse_modified_dt, three_months_dt)
+
+
+class TestEvents(TestOTXv2):
+    def setUp(self, **kwargs):
+        super(TestEvents, self).setUp(**{'api_key': ALIEN_API_APIKEY})
+
+    def test_getevents_since(self):
+        three_months_dt = (datetime.datetime.now() - datetime.timedelta(days=90))
+        three_months_timestamp = three_months_dt.isoformat()
+        events = self.otx.getevents_since(three_months_timestamp, limit=9999)
+        self.assertIsNotNone(events)
+        self.assertTrue(len(events) > 0)
+        most_recent = events[0]
+        print "Next event: {0}".format(most_recent.keys())
+        self.assertIsNotNone(most_recent.get('action', None))
+        self.assertIsNotNone(most_recent.get('created', None))
+        self.assertIsNotNone(most_recent.get('id', None))
+
+
+class TestIndicatorTypes(TestOTXv2):
+    def setUp(self, **kwargs):
+        super(TestIndicatorTypes, self).setUp(**{'api_key': ALIEN_API_APIKEY})
+
+    def test_get_all_indicators(self):
+        indicator_gen = self.otx.get_all_indicators()
+        for indicator in indicator_gen:
+            self.assertIsNotNone(indicator)
+            self.assertIsNotNone(indicator.get('type', None))
+            self.assertIsNotNone(indicator.get('indicator', None))
+            self.assertIsNotNone(indicator.get('description', None))
+
+    def test_get_all_ipv4_indicators(self):
+        ipv4_type_list = [IPv4]
+        ipv4_indicator_gen = self.otx.get_all_indicators(indicator_types=ipv4_type_list)
+        for indicator in ipv4_indicator_gen:
+            self.assertIsNotNone(indicator)
+            self.assertIsNotNone(indicator.get('type', None))
+            self.assertIsNotNone(indicator.get('indicator', None))
+            self.assertIsNotNone(indicator.get('description', None))
+            self.assertTrue(indicator.get('type', '') == IPv4.name)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,16 +1,35 @@
 import unittest
-from OTXv2 import OTXv2
+import datetime
+import dateutil.parser
+
+from utils import generate_rand_string
+from OTXv2 import OTXv2, InvalidAPIKey
+
+ALIEN_API_APIKEY = "48db25670b590ae34850cb13e25397e1e6cad56f2c4f7bdae75a1121dc76bdd0"
 
 
 class TestOTXv2(unittest.TestCase):
-    def setUp(self):
-        self.api_key = "48db25670b590ae34850cb13e25397e1e6cad56f2c4f7bdae75a1121dc76bdd0"
+    def setUp(self, **kwargs):
+        provided_key = kwargs.get('api_key', '')
+        if provided_key:
+            self.api_key = provided_key
+        else:
+            self.api_key = ALIEN_API_APIKEY
         self.otx = OTXv2(self.api_key)
 
 
+class TestSubscriptionsInvalidKey(TestOTXv2):
+    def setUp(self, **kwargs):
+        super(TestSubscriptionsInvalidKey, self).setUp(**{'api_key': generate_rand_string(length=64)})
+
+    def test_getall(self):
+        with self.assertRaises(InvalidAPIKey):
+            self.otx.getall()
+
+
 class TestSubscriptions(TestOTXv2):
-    def setUp(self):
-        super(TestSubscriptions, self).setUp()
+    def setUp(self, **kwargs):
+        super(TestSubscriptions, self).setUp(**{'api_key': ALIEN_API_APIKEY})
 
     def test_getall(self):
         pulses = self.otx.getall()
@@ -24,7 +43,24 @@ class TestSubscriptions(TestOTXv2):
         self.assertIsNotNone(most_recent.get('author_name', None))
         self.assertIsNotNone(most_recent.get('indicators', None))
         self.assertIsNotNone(most_recent.get('created', None))
+        self.assertIsNotNone(most_recent.get('modified', None))
         self.assertIsNotNone(most_recent.get('id', None))
+
+    def test_getall_iter(self):
+        pulse_gen = self.otx.getall_iter()
+        self.assertIsNotNone(pulse_gen)
+        for pulse in pulse_gen:
+            self.assertTrue(pulse.get('name', None))
+
+    def test_getsince(self):
+        year_ago_dt = (datetime.datetime.now() - datetime.timedelta(days=90))
+        year_ago_timestamp = year_ago_dt.isoformat()
+        pulses = self.otx.getsince(year_ago_timestamp, limit=9999)
+        for pulse in pulses:
+            pulse_modified = pulse.get('modified', None)
+            self.assertIsNotNone(pulse_modified)
+            pulse_modified_dt = dateutil.parser.parse(pulse_modified)
+            self.assertGreaterEqual(pulse_modified_dt, year_ago_dt)
 
 
 if __name__ == '__main__':

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ import pprint
 import string
 
 from utils import generate_rand_string
-from OTXv2 import OTXv2, InvalidAPIKey
+from OTXv2 import OTXv2, InvalidAPIKey, BadRequest
 import IndicatorTypes
 
 ALIEN_API_APIKEY = os.getenv('X_OTX_API_KEY', "mysecretkey")
@@ -263,10 +263,8 @@ class TestValidateIndicator(TestOTXv2):
         indicator = generate_rand_string(8, charset=string.ascii_letters).lower()
         indicator_type = IndicatorTypes.DOMAIN
         print("test_validate_invalid_domain submitting indicator: " + indicator)
-        response = self.otx.validate_indicator(indicator=indicator, indicator_type=indicator_type)
-        print ("test_validate_invalid_domain response: {}".format(response))
-        self.assertIsNotNone(response)
-        self.assertTrue('failed' in response.get('status', ''))
+        with self.assertRaises(BadRequest):
+            self.otx.validate_indicator(indicator=indicator, indicator_type=indicator_type)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -245,5 +245,28 @@ class TestPulseCreateInvalidKey(TestOTXv2):
                                   tags=[],
                                   references=[])
 
+
+class TestValidateIndicator(TestOTXv2):
+    def setUp(self, **kwargs):
+        super(TestValidateIndicator, self).setUp(**{'api_key': ALIEN_API_APIKEY})
+
+    def test_validate_valid_domain(self):
+        indicator = generate_rand_string(8, charset=string.ascii_letters).lower() + ".com"
+        indicator_type = IndicatorTypes.DOMAIN
+        print("test_validate_valid_domain submitting (valid-ish) indicator: " + indicator)
+        response = self.otx.validate_indicator(indicator=indicator, indicator_type=indicator_type)
+        print ("test_validate_valid_domain response: {}".format(response))
+        self.assertIsNotNone(response)
+        self.assertTrue('success' in response.get('status', ''))
+
+    def test_validate_invalid_domain(self):
+        indicator = generate_rand_string(8, charset=string.ascii_letters).lower()
+        indicator_type = IndicatorTypes.DOMAIN
+        print("test_validate_invalid_domain submitting indicator: " + indicator)
+        response = self.otx.validate_indicator(indicator=indicator, indicator_type=indicator_type)
+        print ("test_validate_invalid_domain response: {}".format(response))
+        self.assertIsNotNone(response)
+        self.assertTrue('failed' in response.get('status', ''))
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,31 @@
+import unittest
+from OTXv2 import OTXv2
+
+
+class TestOTXv2(unittest.TestCase):
+    def setUp(self):
+        self.api_key = "48db25670b590ae34850cb13e25397e1e6cad56f2c4f7bdae75a1121dc76bdd0"
+        self.otx = OTXv2(self.api_key)
+
+
+class TestSubscriptions(TestOTXv2):
+    def setUp(self):
+        super(TestSubscriptions, self).setUp()
+
+    def test_getall(self):
+        pulses = self.otx.getall()
+        self.assertIsNotNone(pulses)
+        self.assertTrue(len(pulses) > 0)
+        most_recent = pulses[0]
+        print "most recent pulse: {0}".format(most_recent.get('name', ''))
+        self.assertIsNotNone(most_recent.get('id', None))
+        self.assertIsNotNone(most_recent.get('name', None))
+        self.assertIsNotNone(most_recent.get('description', None))
+        self.assertIsNotNone(most_recent.get('author_name', None))
+        self.assertIsNotNone(most_recent.get('indicators', None))
+        self.assertIsNotNone(most_recent.get('created', None))
+        self.assertIsNotNone(most_recent.get('id', None))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+import random
+import string
+
+
+def generate_rand_string(length=12, charset=string.ascii_lowercase):
+    """ Generate a random string with length `length`
+    :param charset: possible characters in generated string
+    :param length: length of string to return
+
+    :return string
+    """
+    return ''.join(random.choice(charset) for _ in range(length))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,10 +3,9 @@ import string
 
 
 def generate_rand_string(length=12, charset=string.ascii_lowercase):
-    """ Generate a random string with length `length`
-    :param charset: possible characters in generated string
-    :param length: length of string to return
-
-    :return string
+    """ Generate a random string
+    :param length: length of string to generate
+    :param charset: allow caller to control charset
+    :return: generated string
     """
     return ''.join(random.choice(charset) for _ in range(length))


### PR DESCRIPTION
This is a backwards compatible update that adds a bunch of new functionality to support the endpoints added to the newly updated [api documentation](https://otx.alienvault.com/api/):
* search (OTXv2.search_pulses, OTXv2.search_users)
* Get pulse by id (OTXv2.pulse_details)
* Indicator details (OTXv2.get_indicator_details_full, OTXv2.get_indicator_details_by_section)
* Create pulse (OTXv2.create_pulse, OTXv2.validate_indicator)

Other minor updates to IndicatorTypes to support indicator details and python notebook updates.
