### PR TITLE
validate_api_key method and urllib improvements

### DIFF
--- a/OTXv2.py
+++ b/OTXv2.py
@@ -82,8 +82,11 @@ class OTXv2(object):
                     raise InvalidAPIKey("Invalid API Key")
                 elif e.code == 400:
                     raise BadRequest("Bad Request")
+                else:
+                    raise e
             else:
                 raise e
+
         data = response.read().decode('utf-8')
         json_data = json.loads(data)
         return json_data
@@ -123,6 +126,10 @@ class OTXv2(object):
                     decoded_error = encoded_error.decode('utf-8')
                     json.loads(decoded_error)
                     raise BadRequest(decoded_error)
+                else:
+                    raise e
+            else:
+                raise e
 
         data = response.read().decode('utf-8')
         json_data = json.loads(data)

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -6,6 +6,7 @@ import IndicatorTypes
 
 # API URLs
 API_V1_ROOT = "{}/api/v1"                                                   # API v1 base path
+USERS_ME = "{0}/users/me".format(API_V1_ROOT)                               # user details
 SUBSCRIBED = "{}/pulses/subscribed".format(API_V1_ROOT)                     # pulse subscriptions
 EVENTS = "{}/pulses/events".format(API_V1_ROOT)                             # events (user actions)
 SEARCH_PULSES = "{}/search/pulses".format(API_V1_ROOT)                      # search pulses
@@ -116,6 +117,20 @@ class OTXv2(object):
                     json.loads(decoded_error)
                     raise BadRequest(decoded_error)
         return {}
+
+    def validate_api_key(self):
+        """
+        Validate the OTX API key.
+
+        :return: True if key is valid, False otherwise
+        :rtype: bool
+        """
+        user_url = self.create_url(USERS_ME)
+        try:
+            self.get(user_url)
+            return True
+        except:
+            return False
 
     def create_pulse(self, **kwargs):
         """

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -56,9 +56,10 @@ class OTXv2(object):
 
     def get(self, url):
         """
-        Internal API for GET request on a OTX URL
+        Internal API for GET request on a OTX URL.
+
         :param url: URL to retrieve
-        :return: response in JSON object form
+        :return: response body in JSON object form
         """
         if self.proxy:
             proxy = ProxyHandler({'http': self.proxy})
@@ -86,10 +87,11 @@ class OTXv2(object):
 
     def post(self, url, body):
         """
-        Internal API for POST request on a OTX URL
+        Internal API for POST request on a OTX URL.
+
         :param url: URL to retrieve
         :param body: HTTP Body to send in request
-        :return: response as dict
+        :return: response body in JSON object form
         """
         request = Request(url)
         request.add_header('X-OTX-API-KEY', self.key)
@@ -135,6 +137,7 @@ class OTXv2(object):
     def create_pulse(self, **kwargs):
         """
         Create a pulse via HTTP Post (Content Type: application/json).
+
         Notes:
             If `TLP` is one of: ['red', 'amber'], `public` must be false.
             `name` field is required
@@ -151,7 +154,7 @@ class OTXv2(object):
             :param references(list of strings, preferably URLs) external references for this threat
             :param indicators(list of objects) IOCs to include in pulse
         :return: request body response
-        :raises BadRequest (400) On failure, BadRequest will be raised containing the invalid fields.
+        :raises BadRequest: on 400 HTTP failure, containing the invalid fields.
 
         Examples:
         Python kwargs can be used in two ways.  You can call create_pulse passing a dict, or named arguments.
@@ -179,6 +182,8 @@ class OTXv2(object):
 
     def validate_indicator(self, indicator_type, indicator, description=""):
         """
+        Validate the indicator type and POST body with the API.
+
         The goal of validate_indicator is to aid you in pulse creation.  Use this method on each indicator before
         calling create_pulse to ensure success in the create call.  If you supply invalid indicators in a create call,
         the pulse will not be created.
@@ -186,7 +191,8 @@ class OTXv2(object):
         :param indicator: indicator value (string)
         :param indicator_type: an IndicatorTypes object (i.e. IndicatorTypes.DOMAIN)
         :param description: a short descriptive string can be sent to the validator for length checking
-        :return:
+        :return: response body in JSON object form
+        :raises ValueError: if indicator or indicator_type are not supplied, and if the indicator type is invalid.
         """
         if not indicator:
             raise ValueError("please supply `indicator` when calling validate_indicator")
@@ -207,9 +213,10 @@ class OTXv2(object):
         return response
 
     def create_url(self, url_path, **kwargs):
-        """ Turn a path into a valid fully formatted URL. Supports query parameter formatting as well.
+        """
+        Turn a path into a valid fully formatted URL. Supports query parameter formatting as well.
 
-        :param url_path: Request path (i.e. "/search/pulses")
+        :param url_path: request path (i.e. "/search/pulses")
         :param kwargs: key value pairs to be added as query parameters (i.e. limit=10, page=5)
         :return: a formatted url (i.e. "/search/pulses")
         """
@@ -224,7 +231,8 @@ class OTXv2(object):
         return uri
 
     def create_indicator_detail_url(self, indicator_type, indicator, section='general'):
-        """ Build a valid indicator detail url.  This api contains all data we have about indicators.
+        """
+        Build a valid indicator detail url. This api contains all data we have about indicators.
 
         Only indicators with IndicatorTypes.api_support = True should be used.
 
@@ -242,7 +250,8 @@ class OTXv2(object):
     def getall(self, limit=20):
         """
         Get all pulses user is subscribed to.
-        :param limit: The page size to retrieve in a single request
+
+        :param limit: the page size to retrieve in a single request
         :return: the consolidated set of pulses for the user
         """
         pulses = []
@@ -257,6 +266,7 @@ class OTXv2(object):
     def getall_iter(self, limit=20):
         """
         Get all pulses user is subscribed to, yield results.
+
         :param limit: The page size to retrieve in a single request
         :return: the consolidated set of pulses for the user
         """
@@ -270,8 +280,9 @@ class OTXv2(object):
     def getsince(self, timestamp, limit=20):
         """
         Get all pulses modified since a particular time.
+
         :param timestamp: iso formatted date time string
-        :param limit: Maximum number of results to return in a single request
+        :param limit: maximum number of results to return in a single request
         :return: the consolidated set of pulses for the user
         """
         pulses = []
@@ -286,8 +297,9 @@ class OTXv2(object):
     def getsince_iter(self, timestamp, limit=20):
         """
         Get all pulses modified since a particular time, yield results.
+
         :param timestamp: iso formatted date time string
-        :param limit: Maximum number of results to return in a single request
+        :param limit: maximum number of results to return in a single request
         :return: the consolidated set of pulses for the user
         """
         next_page_url = self.create_url(SUBSCRIBED, limit=limit, modified_since=timestamp)
@@ -300,9 +312,10 @@ class OTXv2(object):
     def search_pulses(self, query, max_results=25):
         """
         Get all pulses with text matching `query`.
-        :param query: The text to search for
-        :param max_results: Limit the number of pulses returned in response
-        :return: All pulses matching `query`
+
+        :param query: the text to search for
+        :param max_results: limit the number of pulses returned in response
+        :return: all pulses matching `query`
         """
         search_pulses_url = self.create_url(SEARCH_PULSES, q=query, page=1, limit=20)
         return self._get_paginated_resource(search_pulses_url, max_results=max_results)
@@ -310,9 +323,10 @@ class OTXv2(object):
     def search_users(self, query, max_results=25):
         """
         Get all pulses with text matching `query`.
-        :param query: The text to search for
-        :param max_results: Limit the number of users returned in response
-        :return: List of users with username matching `query`
+
+        :param query: the text to search for
+        :param max_results: limit the number of users returned in response
+        :return: list of users with username matching `query`
         """
         search_users_url = self.create_url(SEARCH_USERS, q=query, limit=20, page=1)
         return self._get_paginated_resource(search_users_url, max_results=max_results)
@@ -322,7 +336,7 @@ class OTXv2(object):
         Get all pages of a particular API resource, and retain additional fields.
 
         :param url: URL for first page of a paginated list api. Default is list subscribed pulses.
-        :param max_results: Limit the number of objects returned.
+        :param max_results: limit the number of objects returned.
         :return: results and additional fields as dict
         """
         results = []
@@ -344,7 +358,9 @@ class OTXv2(object):
     def get_all_indicators(self, indicator_types=IndicatorTypes.all_types):
         """
         Get all the indicators contained within your pulses of the IndicatorTypes passed.
+
         By default returns all IndicatorTypes.
+
         :param indicator_types: IndicatorTypes to return
         :return: yields the indicator object for use
         """
@@ -356,9 +372,10 @@ class OTXv2(object):
 
     def getevents_since(self, timestamp, limit=20):
         """
-        Get all events (activity) created or updated since a timestamp
-        :param timestamp: ISO formatted datetime string to restrict results (not older than timestamp).
-        :param limit: The page size to retrieve in a single request
+        Get all events (activity) created or updated since a timestamp.
+
+        :param timestamp: iso formatted datetime string to restrict results (not older than timestamp)
+        :param limit: ihe page size to retrieve in a single request
         :return: the consolidated set of pulses for the user
         """
         events = []
@@ -373,8 +390,9 @@ class OTXv2(object):
     def get_pulse_details(self, pulse_id):
         """
         For a given pulse_id, get the details of an arbitrary pulse.
+
         :param pulse_id: object id for pulse
-        :return: Pulse as dict
+        :return: pulse as dict
         """
         pulse_url = self.create_url(PULSE_DETAILS + str(pulse_id))
         meta_data = self.get(pulse_url)
@@ -382,9 +400,10 @@ class OTXv2(object):
 
     def get_pulse_indicators(self, pulse_id):
         """
-        For a given pulse_id, get list of indicators (IOCs)
-        :param pulse_id: Object ID specify which pulse to get indicators from
-        :return: Indicator list
+        For a given pulse_id, get list of indicators (IOCs).
+
+        :param pulse_id: object id for pulse
+        :return: indicators as dict
         """
         pulse_url = self.create_url(PULSE_DETAILS + str(pulse_id) + "/indicators")
         pulse_indicators_url = pulse_url
@@ -394,11 +413,12 @@ class OTXv2(object):
     def get_indicator_details_by_section(self, indicator_type, indicator, section='general'):
         """
         The Indicator details endpoints are split into sections.  Obtain a specific section for an indicator.
+
         :param indicator_type: IndicatorType instance
         :param indicator: String indicator (i.e. "69.73.130.198", "mail.vspcord.com")
         :param section: Section from IndicatorTypes.section.  Default is general info
-        :return: Return indicator details as dict
-
+        :return: indicator details as dict
+        :raises TypeError: if the indicator_type and/or the section are not supported
         """
         if not indicator_type.api_support:
             raise TypeError("IndicatorType {0} is not currently supported.".format(indicator_type))
@@ -411,9 +431,10 @@ class OTXv2(object):
     def get_indicator_details_full(self, indicator_type, indicator):
         """
         Obtain all sections for an indicator.
+
         :param indicator_type: IndicatorType instance
         :param indicator: String indicator (i.e. "69.73.130.198", "mail.vspcord.com")
-        :return: dict with sections as keys and results for each call as values.
+        :return: dict with sections as keys and results for each call as values
         """
         indicator_dict = {}
         for section in indicator_type.sections:

--- a/OTXv2.py
+++ b/OTXv2.py
@@ -20,11 +20,13 @@ VALIDATE_INDICATOR = "{}/pulses/indicators/validate".format(API_V1_ROOT)    # in
 
 try:
     # For Python2
-    from urllib2 import URLError, HTTPError, build_opener, ProxyHandler, urlopen, Request
+    from urllib2 import URLError, HTTPError, build_opener, ProxyHandler, Request
+    from urllib import urlencode
 except ImportError:
     # For Python3
     from urllib.error import URLError, HTTPError
-    from urllib.request import build_opener, ProxyHandler, urlopen, Request
+    from urllib.request import build_opener, ProxyHandler, Request
+    from urllib.parse import urlencode
 
 
 class InvalidAPIKey(Exception):
@@ -53,6 +55,10 @@ class OTXv2(object):
         self.server = server
         self.proxy = proxy
         self.sdk = 'OTX Python {}/1.1'.format(project)
+        self.headers = {
+            'X-OTX-API-KEY': self.key,
+            'User-Agent': self.sdk
+        }
 
     def get(self, url):
         """
@@ -61,18 +67,15 @@ class OTXv2(object):
         :param url: URL to retrieve
         :return: response body in JSON object form
         """
+        opener = build_opener()
         if self.proxy:
             proxy = ProxyHandler({'http': self.proxy})
-            request = build_opener(proxy)
-        else:
-            request = build_opener()
-        request.addheaders = [
-            ('X-OTX-API-KEY', self.key),
-            ('User-Agent', self.sdk)
-        ]
-        response = None
+            opener.add_handler(proxy)
+
+        request = Request(url, headers=self.headers)
+
         try:
-            response = request.open(url)
+            response = opener.open(request)
         except URLError as e:
             if isinstance(e, HTTPError):
                 if e.code == 403:
@@ -93,22 +96,24 @@ class OTXv2(object):
         :param body: HTTP Body to send in request
         :return: response body in JSON object form
         """
-        request = Request(url)
-        request.add_header('X-OTX-API-KEY', self.key)
-        request.add_header('User-Agent', self.sdk)
+        opener = build_opener()
+        if self.proxy:
+            proxy = ProxyHandler({'http': self.proxy})
+            opener.add_handler(proxy)
+
+        request = Request(url, headers=self.headers)
         request.add_header("Content-Type", "application/json")
+
         method = "POST"
         request.get_method = lambda: method
         if body:
             try:  # python2
                 request.add_data(json.dumps(body))
-            except AttributeError as ae:  # python3
+            except AttributeError:  # python3
                 request.data = json.dumps(body).encode('utf-8')
+
         try:
-            response = urlopen(request)
-            data = response.read().decode('utf-8')
-            json_data = json.loads(data)
-            return json_data
+            response = opener.open(request)
         except URLError as e:
             if isinstance(e, HTTPError):
                 if e.code == 403:
@@ -118,7 +123,10 @@ class OTXv2(object):
                     decoded_error = encoded_error.decode('utf-8')
                     json.loads(decoded_error)
                     raise BadRequest(decoded_error)
-        return {}
+
+        data = response.read().decode('utf-8')
+        json_data = json.loads(data)
+        return json_data
 
     def validate_api_key(self):
         """
@@ -222,12 +230,7 @@ class OTXv2(object):
         """
         uri = url_path.format(self.server)
         if kwargs.items():
-            uri += "?"
-            for parameter, value in kwargs.items():
-                uri += parameter
-                uri += "="
-                uri += str(value)
-                uri += "&"
+            uri += '?' + urlencode(kwargs)
         return uri
 
     def create_indicator_detail_url(self, indicator_type, indicator, section='general'):

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,5 @@ setup(name='OTXv2',
       author_email='otx@alienvault.com',
       url='https://github.com/AlienVault-Labs/OTX-Python-SDK',
       download_url='https://github.com/AlienVault-Labs/OTX-Python-SDK/tarball/1.1.0',
-      py_modules=['OTXv2', 'IndicatorTypes'],
-      install_requires=['simplejson']
+      py_modules=['OTXv2', 'IndicatorTypes']
       )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ import os
 import pprint
 import string
 
-from tests.utils import generate_rand_string
+from utils import generate_rand_string
 from OTXv2 import OTXv2, InvalidAPIKey, BadRequest
 import IndicatorTypes
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ import os
 import pprint
 import string
 
-from utils import generate_rand_string
+from tests.utils import generate_rand_string
 from OTXv2 import OTXv2, InvalidAPIKey, BadRequest
 import IndicatorTypes
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,6 +17,7 @@ class TestOTXv2(unittest.TestCase):
     """
     Base class configure API Key to use on a per test basis.
     """
+
     def setUp(self, **kwargs):
         provided_key = kwargs.get('api_key', '')
         if provided_key:
@@ -26,10 +27,27 @@ class TestOTXv2(unittest.TestCase):
         self.otx = OTXv2(self.api_key)
 
 
+class TestValidateAPIKey(TestOTXv2):
+    """
+    Confirm expected boolean results for validating the API Key.
+    """
+
+    def test_validate_valid_key(self):
+        super(TestValidateAPIKey, self).setUp()
+        res = self.otx.validate_api_key()
+        self.assertTrue(res)
+
+    def test_validate_invalid_key(self):
+        super(TestValidateAPIKey, self).setUp(**{'api_key': generate_rand_string(length=64)})
+        res = self.otx.validate_api_key()
+        self.assertFalse(res)
+
+
 class TestSubscriptionsInvalidKey(TestOTXv2):
     """
     Confirm InvalidAPIKey class is raised for API Key failures
     """
+
     def setUp(self, **kwargs):
         super(TestSubscriptionsInvalidKey, self).setUp(**{'api_key': generate_rand_string(length=64)})
 
@@ -42,6 +60,7 @@ class TestSubscriptions(TestOTXv2):
     """
     Confirm that given a valid API Key, we can obtain threat intelligence subscriptions.
     """
+
     def setUp(self, **kwargs):
         super(TestSubscriptions, self).setUp(**{'api_key': ALIEN_API_APIKEY})
 


### PR DESCRIPTION
I'm pretty new to git collaboration. I don't know what is the 'git way' of doing things, but this pull request has ~~3~~ 4 commits and introduces a few things:

- New:
 - Added a `validate_api_key` method and a corresponding `TestValidateAPIKey` test.
- Tests module:
 - Merged both `TestSubscriptionsInvalidKey` and `TestPulseCreateInvalidKey` (which effectively test the internal `get` and `post` using an invalid key) into one class called `TestInvalidAPIKeyException`.
 - Removed all the `setUp` functions since all the classes subclass the base `TestOTXv2`.
 - Added docstrings to each class, it was bothering me that some had it and some didn't.
- `urllib` implementation improvements:
 - Added proxy support to the `post` module (only `get` got it from pull request https://github.com/AlienVault-Labs/OTX-Python-SDK/pull/10).
 - For some reason, `post` was a little different than `get` in the way it returned the response data. Was there a reason for that? 
 - Unified the way we submit requests using `build_opener` and `Request`. You will now notice that `get` and `post` are pretty similar to each other; this can allow us to further abstract them by creating a `def REST(url, method):` or something similar.
- `create_url`:
 - Now uses `urlencode` to encode the key=value pairs. This fixes issue https://github.com/AlienVault-Labs/OTX-Python-SDK/issues/18 where search queries weren't properly encoded.
- Fixed error handling to re-`raise` the swallowed exceptions under `HTTPError` and `URLError`.
- Removed `simplejson` and `install_requires` since we switched to `json` in commit https://github.com/AlienVault-Labs/OTX-Python-SDK/commit/10d845af6c9beaf5ce3efe91085f42941c017261 (can we leave an empty `install_requires=[]` instead?).

Side note: it looks like Travis builds will always fail because our config doesn't include an API key. Is there no generic key we can use in `.travis.yml` and set it using `env`?